### PR TITLE
Erste Konzepte und Regeln für Isy-Konfiguration angelegt

### DIFF
--- a/jqassistant/default.adoc
+++ b/jqassistant/default.adoc
@@ -6,7 +6,7 @@
 = IsyFact Architektur- und Design-Regeln
 
 [[default]]
-[role=group,includesGroups="package:Default,layer:Default,logging:Default"]
+[role=group,includesGroups="package:Default,layer:Default,logging:Default,konfiguration:Default"]
 == Einführung
 
 Dieses Dokument beschreibt Konzepte und Constraints der Anwendung.
@@ -19,4 +19,5 @@ include::maven.adoc[]
 include::package.adoc[]
 include::layer.adoc[]
 include::logging.adoc[]
+include::konfiguration.adoc[]
 

--- a/jqassistant/konfiguration.adoc
+++ b/jqassistant/konfiguration.adoc
@@ -1,0 +1,63 @@
+[[konfiguration:Default]]
+[role=group,includesConstraints="konfiguration:SpeichereKeineKonfigurationsParameter,konfiguration:BenutzeKeineInternenKlassen"]]
+== Konfiguration
+
+Dieser Abschnitt beschreibt Regeln für die Konfiguration einer Anwendung.
+
+Für die Abfrage von Konfigurationsparametern wird grundsätzlich das Interface `Konfiguration` verwendet, das über ein Spring Bean bereitgestellt wird.
+
+[source,java]
+----
+@Component
+public class MyClass {
+
+  private final Konfiguration konfiguration;
+
+  @Autowired
+  public MyClass(Konfiguration konfiguration) {
+     this.konfiguration = konfiguration;
+  }
+
+}
+----
+
+=== Konzepte
+[[konfiguration:IsyKonfiguration]]
+.Markiert die Konfiguration vom Typ `de.bund.bva.pliscommon.konfiguration.common.Konfiguration` mit `Konfiguration`.
+[source,cypher,role=concept]
+----
+MATCH
+  (type:Type)-[:DECLARES]->(konfiguration:Field)-[:OF_TYPE]->(fieldType:Type)
+WHERE
+  fieldType.fqn = "de.bund.bva.pliscommon.konfiguration.common.Konfiguration"
+SET
+  konfiguration:Konfiguration
+RETURN
+  type.fqn as Klasse, konfiguration.name as Feld
+----
+
+=== Regeln
+[[konfiguration:BenutzeKeineInternenKlassen]]
+.Es dürfen keine Klassen aus dem Package `de.bund.bva.pliscommon.konfiguration.common.impl.` verwendet werden.
+[source,cypher,role=constraint]
+----
+MATCH
+  (type:Type)-[*]->(fieldType:Type)
+WHERE
+  fieldType.fqn STARTS WITH "de.bund.bva.pliscommon.konfiguration.common.impl."
+RETURN
+  type.name as Klasse, fieldType.name as UngültigeReferenz, count(fieldType.name) as Anzahl
+----
+
+[[konfiguration:SpeichereKeineKonfigurationsParameter]]
+.Konfigurationswerte dürfen nicht in Feldern eines Objekts gespeichert werden.
+[source,cypher,role=constraint,requiresConcepts="konfiguration:IsyKonfiguration"]
+----
+MATCH
+  (type:Type)-[:DECLARES]->(field:Field)<-[writes:WRITES]-(:Method)-[invokes:INVOKES]->(:Method)<-[:DECLARES]-(konfType:Type)
+WHERE
+  konfType.fqn = "de.bund.bva.pliscommon.konfiguration.common.Konfiguration" AND
+  writes.lineNumber = invokes.lineNumber
+RETURN
+  type.name as Klasse, field.name as Feld, invokes.lineNumber as Zeile
+----

--- a/src/test/java/de/msg/terminfindung/jqassistant/JQAssistantViolationTest.java
+++ b/src/test/java/de/msg/terminfindung/jqassistant/JQAssistantViolationTest.java
@@ -1,0 +1,31 @@
+package de.msg.terminfindung.jqassistant;
+
+import de.bund.bva.pliscommon.konfiguration.common.Konfiguration;
+import de.bund.bva.pliscommon.konfiguration.common.impl.AbstractKonfiguration;
+import de.bund.bva.pliscommon.konfiguration.common.impl.PropertyKonfiguration;
+import de.msg.terminfindung.common.konstanten.KonfigurationSchluessel;
+
+/**
+ * Test für die Constraints von JQAssistant.
+ */
+public class JQAssistantViolationTest {
+
+    private Konfiguration konfiguration;
+
+    // Verletzung von konfiguration:BenutzeKeineInternenKlassen
+    private PropertyKonfiguration propertyKonfiguration;
+
+    private String quatsch;
+
+    public JQAssistantViolationTest(PropertyKonfiguration konfiguration, Konfiguration konf2) {
+        propertyKonfiguration = konfiguration;
+        this.konfiguration = konf2;
+
+        // Verletzung von konfiguration:SpeichereKeineKonfigurationsParameter
+        quatsch = this.konfiguration.getAsString(KonfigurationSchluessel.BATCH_ORGANISATION);
+        quatsch = konf2.getAsString(KonfigurationSchluessel.BATCH_ORGANISATION);
+
+        ((AbstractKonfiguration) propertyKonfiguration).getAsBoolean(KonfigurationSchluessel.BATCH_ORGANISATION);
+    }
+
+}


### PR DESCRIPTION
Ein Konzept und zwei Regeln für die Konfiguration angelegt sowie eine Testklasse hinzugefügt, um Verletzungen der Regeln zu provozieren.